### PR TITLE
fix(skipdir): added filepath.skipdir

### DIFF
--- a/internal/lib/generate.go
+++ b/internal/lib/generate.go
@@ -36,6 +36,7 @@ func Generate() {
 				}
 				// add the repo to the repos map
 				repos[path] = url
+				return filepath.SkipDir
 			}
 
 			return nil


### PR DESCRIPTION
Previously, the program checked for each file and folder and now as soon as it encounters a .git subdirectory it would not search the directory ffurther

https://github.com/automation-co/borzoi/issues/18